### PR TITLE
Update to Jammy, Impish no longer supported/buildable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-# impish is needed since glibc 2.34 is required for linux 5.15.30
-FROM ubuntu:impish-20220316
+FROM ubuntu:jammy-20220815
 
 # according to https://www.raspberrypi.com/documentation/computers/linux_kernel.html#cross-compiling-the-kernel
 RUN apt-get update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# glibc 2.34 is required for linux 5.15.30 (available since ubuntu:impish or debian:bookworm)
 FROM ubuntu:jammy-20220815
 
 # according to https://www.raspberrypi.com/documentation/computers/linux_kernel.html#cross-compiling-the-kernel

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:jammy-20220815
 # according to https://www.raspberrypi.com/documentation/computers/linux_kernel.html#cross-compiling-the-kernel
 RUN apt-get update && \
     apt-get install -y  git bc bison flex libssl-dev make libc6-dev libncurses5-dev \
-                        crossbuild-essential-armhf
+                        crossbuild-essential-armhf kmod
 
 # to compile go programs
 RUN apt-get -y install golang-go gcc-arm-linux-gnueabi

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,6 @@ RUN apt-get update && \
     apt-get install -y  git bc bison flex libssl-dev make libc6-dev libncurses5-dev \
                         crossbuild-essential-armhf kmod
 
-# to compile go programs
-RUN apt-get -y install golang-go gcc-arm-linux-gnueabi
 
 ENV KERNEL kernel
 ENV ARCH arm

--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@ This repository hosts a docker container for cross-compiling the 32 bits Linux b
 ```
 docker run --rm \
     -v /path/to/the/kernel:/root/armhr \
-    ghcr.io/gokrazy-community/crossbuild-armhf:impish-20220316 \
+    ghcr.io/gokrazy-community/crossbuild-armhf:jammy-20220815 \
     make zImage
 ```


### PR DESCRIPTION
The impish image is (as Impish has been out of support since July 2022) no longer buildable.
Update to Jammy (22.04 LTS) instead.

Also add `kmod` for `depmod` so modules can be built with this image (needed for wifi/bt)