### PR TITLE
Dockerfile: fix format of ENV lines

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,9 @@ RUN apt-get update && \
                         crossbuild-essential-armhf kmod
 
 
-ENV KERNEL kernel
-ENV ARCH arm
-ENV CROSS_COMPILE arm-linux-gnueabihf-
+ENV KERNEL=kernel
+ENV ARCH=arm
+ENV CROSS_COMPILE=arm-linux-gnueabihf-
 
 WORKDIR /root/armhf
 


### PR DESCRIPTION
Fix Docker warnings about ENV lines:
```
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 11)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 12)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 10)
 ```